### PR TITLE
Don't add 2 newlines if nothing in table

### DIFF
--- a/internal/types/action.go
+++ b/internal/types/action.go
@@ -102,7 +102,7 @@ func (a *Action) WriteDocumentation(inputTable, outputTable *strings.Builder) er
 
 	if hasOutputsData {
 		output = utils.ReplaceBytesInBetween(output, outputStartIndex, outputEndIndex, []byte(outputsStr))
-	} else if outputTable.String() != "" {
+	} else {
 		output = bytes.Replace(output, []byte(internal.OutputsHeader), []byte(outputsStr), -1)
 	}
 

--- a/internal/types/action.go
+++ b/internal/types/action.go
@@ -26,9 +26,10 @@ import (
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
 	"github.com/tj-actions/auto-doc/internal"
 	"github.com/tj-actions/auto-doc/internal/utils"
-	"gopkg.in/yaml.v3"
 )
 
 // ActionInput represents the input of the action.yml
@@ -83,14 +84,12 @@ func (a *Action) WriteDocumentation(inputTable, outputTable *strings.Builder) er
 		[]byte(internal.InputAutoDocEnd),
 	)
 
+	inputsStr := strings.TrimSpace(fmt.Sprintf("%s\n\n%v", internal.InputsHeader, inputTable.String()))
+
 	if hasInputsData {
-		inputsStr := fmt.Sprintf("%s\n\n%v", internal.InputsHeader, inputTable.String())
 		output = utils.ReplaceBytesInBetween(input, inputStartIndex, inputEndIndex, []byte(inputsStr))
 	} else {
-		inputsStr := fmt.Sprintf("%s\n\n%v", internal.InputsHeader, inputTable.String())
-		if inputTable.String() != "" {
-			output = bytes.Replace(input, []byte(internal.InputsHeader), []byte(inputsStr), -1)
-		}
+		output = bytes.Replace(input, []byte(internal.InputsHeader), []byte(inputsStr), -1)
 	}
 
 	hasOutputsData, outputStartIndex, outputEndIndex := utils.HasBytesInBetween(
@@ -99,14 +98,12 @@ func (a *Action) WriteDocumentation(inputTable, outputTable *strings.Builder) er
 		[]byte(internal.OutputAutoDocEnd),
 	)
 
+	outputsStr := strings.TrimSpace(fmt.Sprintf("%s\n\n%v", internal.OutputsHeader, outputTable.String()))
+
 	if hasOutputsData {
-		outputsStr := fmt.Sprintf("%s\n\n%v", internal.OutputsHeader, outputTable.String())
 		output = utils.ReplaceBytesInBetween(output, outputStartIndex, outputEndIndex, []byte(outputsStr))
-	} else {
-		outputsStr := fmt.Sprintf("%s\n\n%v", internal.OutputsHeader, outputTable.String())
-		if outputTable.String() != "" {
-			output = bytes.Replace(output, []byte(internal.OutputsHeader), []byte(outputsStr), -1)
-		}
+	} else if outputTable.String() != "" {
+		output = bytes.Replace(output, []byte(internal.OutputsHeader), []byte(outputsStr), -1)
 	}
 
 	if len(output) > 0 {

--- a/internal/types/action.go
+++ b/internal/types/action.go
@@ -19,15 +19,16 @@ package types
 import (
 	"bytes"
 	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 	"github.com/tj-actions/auto-doc/internal"
 	"github.com/tj-actions/auto-doc/internal/utils"
 	"gopkg.in/yaml.v3"
-	"os"
-	"sort"
-	"strconv"
-	"strings"
 )
 
 // ActionInput represents the input of the action.yml
@@ -87,7 +88,9 @@ func (a *Action) WriteDocumentation(inputTable, outputTable *strings.Builder) er
 		output = utils.ReplaceBytesInBetween(input, inputStartIndex, inputEndIndex, []byte(inputsStr))
 	} else {
 		inputsStr := fmt.Sprintf("%s\n\n%v", internal.InputsHeader, inputTable.String())
-		output = bytes.Replace(input, []byte(internal.InputsHeader), []byte(inputsStr), -1)
+		if inputTable.String() != "" {
+			output = bytes.Replace(input, []byte(internal.InputsHeader), []byte(inputsStr), -1)
+		}
 	}
 
 	hasOutputsData, outputStartIndex, outputEndIndex := utils.HasBytesInBetween(
@@ -101,7 +104,9 @@ func (a *Action) WriteDocumentation(inputTable, outputTable *strings.Builder) er
 		output = utils.ReplaceBytesInBetween(output, outputStartIndex, outputEndIndex, []byte(outputsStr))
 	} else {
 		outputsStr := fmt.Sprintf("%s\n\n%v", internal.OutputsHeader, outputTable.String())
-		output = bytes.Replace(output, []byte(internal.OutputsHeader), []byte(outputsStr), -1)
+		if outputTable.String() != "" {
+			output = bytes.Replace(output, []byte(internal.OutputsHeader), []byte(outputsStr), -1)
+		}
 	}
 
 	if len(output) > 0 {

--- a/internal/types/reusable.go
+++ b/internal/types/reusable.go
@@ -19,15 +19,16 @@ package types
 import (
 	"bytes"
 	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 	"github.com/tj-actions/auto-doc/internal"
 	"github.com/tj-actions/auto-doc/internal/utils"
 	"gopkg.in/yaml.v3"
-	"os"
-	"sort"
-	"strconv"
-	"strings"
 )
 
 // ReusableInput represents the input of the reusable workflow
@@ -97,9 +98,12 @@ func (r *Reusable) WriteDocumentation(inputTable, outputTable, secretsTable *str
 	if hasInputsData {
 		inputsStr := fmt.Sprintf("%s\n\n%v", internal.InputsHeader, inputTable.String())
 		output = utils.ReplaceBytesInBetween(input, inputStartIndex, inputEndIndex, []byte(inputsStr))
+
 	} else {
 		inputsStr := fmt.Sprintf("%s\n\n%v", internal.InputsHeader, inputTable.String())
-		output = bytes.Replace(input, []byte(internal.InputsHeader), []byte(inputsStr), -1)
+		if inputTable.String() != "" {
+			output = bytes.Replace(input, []byte(internal.InputsHeader), []byte(inputsStr), -1)
+		}
 	}
 
 	hasOutputsData, outputStartIndex, outputEndIndex := utils.HasBytesInBetween(
@@ -113,7 +117,9 @@ func (r *Reusable) WriteDocumentation(inputTable, outputTable, secretsTable *str
 		output = utils.ReplaceBytesInBetween(output, outputStartIndex, outputEndIndex, []byte(outputsStr))
 	} else {
 		outputsStr := fmt.Sprintf("%s\n\n%v", internal.OutputsHeader, outputTable.String())
-		output = bytes.Replace(output, []byte(internal.OutputsHeader), []byte(outputsStr), -1)
+		if outputTable.String() != "" {
+			output = bytes.Replace(output, []byte(internal.OutputsHeader), []byte(outputsStr), -1)
+		}
 	}
 
 	hasSecretsData, secretsStartIndex, secretsEndIndex := utils.HasBytesInBetween(
@@ -127,7 +133,9 @@ func (r *Reusable) WriteDocumentation(inputTable, outputTable, secretsTable *str
 		output = utils.ReplaceBytesInBetween(output, secretsStartIndex, secretsEndIndex, []byte(secretsStr))
 	} else {
 		secretsStr := fmt.Sprintf("%s\n\n%v", internal.SecretsHeader, secretsTable.String())
-		output = bytes.Replace(output, []byte(internal.SecretsHeader), []byte(secretsStr), -1)
+		if secretsTable.String() != "" {
+			output = bytes.Replace(output, []byte(internal.SecretsHeader), []byte(secretsStr), -1)
+		}
 	}
 
 	if len(output) > 0 {

--- a/internal/types/reusable.go
+++ b/internal/types/reusable.go
@@ -26,9 +26,10 @@ import (
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
 	"github.com/tj-actions/auto-doc/internal"
 	"github.com/tj-actions/auto-doc/internal/utils"
-	"gopkg.in/yaml.v3"
 )
 
 // ReusableInput represents the input of the reusable workflow
@@ -94,16 +95,13 @@ func (r *Reusable) WriteDocumentation(inputTable, outputTable, secretsTable *str
 		[]byte(internal.InputsHeader),
 		[]byte(internal.InputAutoDocEnd),
 	)
+	
+	inputsStr := strings.TrimSpace(fmt.Sprintf("%s\n\n%v", internal.InputsHeader, inputTable.String()))
 
 	if hasInputsData {
-		inputsStr := fmt.Sprintf("%s\n\n%v", internal.InputsHeader, inputTable.String())
 		output = utils.ReplaceBytesInBetween(input, inputStartIndex, inputEndIndex, []byte(inputsStr))
-
 	} else {
-		inputsStr := fmt.Sprintf("%s\n\n%v", internal.InputsHeader, inputTable.String())
-		if inputTable.String() != "" {
-			output = bytes.Replace(input, []byte(internal.InputsHeader), []byte(inputsStr), -1)
-		}
+		output = bytes.Replace(input, []byte(internal.InputsHeader), []byte(inputsStr), -1)
 	}
 
 	hasOutputsData, outputStartIndex, outputEndIndex := utils.HasBytesInBetween(
@@ -112,14 +110,12 @@ func (r *Reusable) WriteDocumentation(inputTable, outputTable, secretsTable *str
 		[]byte(internal.OutputAutoDocEnd),
 	)
 
+	outputsStr := strings.TrimSpace(fmt.Sprintf("%s\n\n%v", internal.OutputsHeader, outputTable.String()))
+
 	if hasOutputsData {
-		outputsStr := fmt.Sprintf("%s\n\n%v", internal.OutputsHeader, outputTable.String())
 		output = utils.ReplaceBytesInBetween(output, outputStartIndex, outputEndIndex, []byte(outputsStr))
 	} else {
-		outputsStr := fmt.Sprintf("%s\n\n%v", internal.OutputsHeader, outputTable.String())
-		if outputTable.String() != "" {
-			output = bytes.Replace(output, []byte(internal.OutputsHeader), []byte(outputsStr), -1)
-		}
+		output = bytes.Replace(output, []byte(internal.OutputsHeader), []byte(outputsStr), -1)
 	}
 
 	hasSecretsData, secretsStartIndex, secretsEndIndex := utils.HasBytesInBetween(
@@ -127,15 +123,13 @@ func (r *Reusable) WriteDocumentation(inputTable, outputTable, secretsTable *str
 		[]byte(internal.SecretsHeader),
 		[]byte(internal.SecretsAutoDocEnd),
 	)
+	
+	secretsStr := strings.TrimSpace(fmt.Sprintf("%s\n\n%v", internal.SecretsHeader, secretsTable.String()))
 
 	if hasSecretsData {
-		secretsStr := fmt.Sprintf("%s\n\n%v", internal.SecretsHeader, secretsTable.String())
 		output = utils.ReplaceBytesInBetween(output, secretsStartIndex, secretsEndIndex, []byte(secretsStr))
 	} else {
-		secretsStr := fmt.Sprintf("%s\n\n%v", internal.SecretsHeader, secretsTable.String())
-		if secretsTable.String() != "" {
-			output = bytes.Replace(output, []byte(internal.SecretsHeader), []byte(secretsStr), -1)
-		}
+		output = bytes.Replace(output, []byte(internal.SecretsHeader), []byte(secretsStr), -1)
 	}
 
 	if len(output) > 0 {


### PR DESCRIPTION
Only replace headers if there are documentation to add.

If you add a header ex. `## Outputs` but the action or reusable workflow does not have any outputs defined 2 newlines will be added after the header for each run of auto-doc.

```
## Outputs
```

becomes

```
## Outputs


```

and after 3rd run

```
## Outputs




```

It's the same for Inputs and Secrets