### PR TITLE
Adding Description heading for Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ GitHub Action that generates beautiful, easy-to-read markdown tables with just a
 
 ## Usage
 
-Add the `Inputs` and/or `Outputs` and/or `Secrets` (only supported by reusable workflows) [`H2` header](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#headers) to any markdown file.
+Add the `Inputs` and/or `Outputs` and/or `Secrets` (only supported by reusable workflows) and/or `Description` (only supported by actions) [`H2` header](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#headers) to any markdown file.
 
 ```yaml
 ...

--- a/README.md
+++ b/README.md
@@ -47,7 +47,10 @@ GitHub Action that generates beautiful, easy-to-read markdown tables with just a
 
 ## Usage
 
-Add the `Inputs` and/or `Outputs` and/or `Secrets` (only supported by reusable workflows) and/or `Description` (only supported by actions) [`H2` header](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#headers) to any markdown file.
+Add the `Inputs` and/or `Outputs`
+and/or `Secrets` (only supported by reusable workflows)
+and/or `Description` (only supported by actions)
+[`H2` header](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#headers) to any markdown file.
 
 ```yaml
 ...
@@ -61,21 +64,21 @@ Add the `Inputs` and/or `Outputs` and/or `Secrets` (only supported by reusable w
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 
-|          INPUT          |  TYPE  | REQUIRED |    DEFAULT     |                                           DESCRIPTION                                            |
-|-------------------------|--------|----------|----------------|--------------------------------------------------------------------------------------------------|
-|        bin\_path         | string |  false   |                |                                   Path to the auto-doc binary                                    |
-|      col\_max\_width      | string |  false   |    `"1000"`    |                                      Max width of a column                                       |
-|      col\_max\_words      | string |  false   |     `"5"`      |                          Max number of words per line <br>in a column                            |
-|        filename         | string |  false   | `"action.yml"` |                                      Path to the yaml file                                       |
-|      input\_columns      | string |  false   |                |    List of action.yml **input** columns names <br>to display, default (display all columns)      |
-|     markdown\_links      | string |  false   |    `"true"`    |  Boolean indicating whether to output input, <br>output and secret names as markdown <br>links   |
-|         output          | string |  false   | `"README.md"`  |                                     Path to the output file                                      |
-|     output\_columns      | string |  false   |                |    List of action.yml **output** column names <br>to display, default (display all columns)      |
-|        reusable         | string |  false   |                |                 Boolean Indicating whether the file is <br>a reusable workflow                   |
-| reusable\_input\_columns  | string |  false   |                | List of reusable workflow **input** column <br>names to display, default (display all columns)   |
-| reusable\_output\_columns | string |  false   |                | List of reusable workflow **output** column <br>names to display, default (display all columns)  |
-| reusable\_secret\_columns | string |  false   |                | List of reusable workflow **secret** column <br>names to display, default (display all columns)  |
-|         version         | string |  false   |                |                                    The version number to run                                     |
+| INPUT                     | TYPE   | REQUIRED | DEFAULT        | DESCRIPTION                                                                                     |
+|---------------------------|--------|----------|----------------|-------------------------------------------------------------------------------------------------|
+| bin\_path                 | string | false    |                | Path to the auto-doc binary                                                                     |
+| col\_max\_width           | string | false    | `"1000"`       | Max width of a column                                                                           |
+| col\_max\_words           | string | false    | `"5"`          | Max number of words per line <br>in a column                                                    |
+| filename                  | string | false    | `"action.yml"` | Path to the yaml file                                                                           |
+| input\_columns            | string | false    |                | List of action.yml **input** columns names <br>to display, default (display all columns)        |
+| markdown\_links           | string | false    | `"true"`       | Boolean indicating whether to output input, <br>output and secret names as markdown <br>links   |
+| output                    | string | false    | `"README.md"`  | Path to the output file                                                                         |
+| output\_columns           | string | false    |                | List of action.yml **output** column names <br>to display, default (display all columns)        |
+| reusable                  | string | false    |                | Boolean Indicating whether the file is <br>a reusable workflow                                  |
+| reusable\_input\_columns  | string | false    |                | List of reusable workflow **input** column <br>names to display, default (display all columns)  |
+| reusable\_output\_columns | string | false    |                | List of reusable workflow **output** column <br>names to display, default (display all columns) |
+| reusable\_secret\_columns | string | false    |                | List of reusable workflow **secret** column <br>names to display, default (display all columns) |
+| version                   | string | false    |                | The version number to run                                                                       |
 
 <!-- AUTO-DOC-INPUT:END -->
 

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -42,10 +42,10 @@ const PipeSeparator = "|"
 // NewLineSeparator used for splitting lines
 const NewLineSeparator = "\n"
 
-// InputAutoDocStart is the start of the input
+// DescriptionAutoDocStart is the start of the description
 var DescriptionAutoDocStart = fmt.Sprintf(AutoDocStart, "DESCRIPTION")
 
-// InputAutoDocEnd is the end of the input
+// DescriptionAutoDocEnd is the end of the description
 var DescriptionAutoDocEnd = fmt.Sprintf(AutoDocEnd, "DESCRIPTION")
 
 // InputAutoDocStart is the start of the input

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -18,6 +18,9 @@ package internal
 
 import "fmt"
 
+// DescriptionHeader represents the markdown header of description
+const DescriptionHeader = "## Description"
+
 // InputsHeader represents the markdown header of inputs
 const InputsHeader = "## Inputs"
 
@@ -38,6 +41,12 @@ const PipeSeparator = "|"
 
 // NewLineSeparator used for splitting lines
 const NewLineSeparator = "\n"
+
+// InputAutoDocStart is the start of the input
+var DescriptionAutoDocStart = fmt.Sprintf(AutoDocStart, "DESCRIPTION")
+
+// InputAutoDocEnd is the end of the input
+var DescriptionAutoDocEnd = fmt.Sprintf(AutoDocEnd, "DESCRIPTION")
 
 // InputAutoDocStart is the start of the input
 var InputAutoDocStart = fmt.Sprintf(AutoDocStart, "INPUT")

--- a/internal/types/action.go
+++ b/internal/types/action.go
@@ -57,7 +57,7 @@ type Action struct {
 	OutputColumns      []string
 	Inputs             map[string]ActionInput  `yaml:"inputs,omitempty"`
 	Outputs            map[string]ActionOutput `yaml:"outputs,omitempty"`
-    Description        string `yaml:"description,omitempty"`
+	Description        string                  `yaml:"description,omitempty"`
 	InputMarkdownLinks bool
 }
 
@@ -82,17 +82,16 @@ func (a *Action) WriteDocumentation(inputTable, outputTable, description *string
 
 	var output []byte
 
-    hasDescriptionData, indices := utils.HasBytesInBetween(
+	hasDescriptionData, indices := utils.HasBytesInBetween(
 		input,
 		[]byte(internal.DescriptionAutoDocStart),
 		[]byte(internal.DescriptionAutoDocEnd),
 	)
-    output = input
+	output = input
 
-    descriptionStr := strings.TrimSpace(description.String())
+	descriptionStr := strings.TrimSpace(description.String())
 
-
-    if hasDescriptionData {
+	if hasDescriptionData {
 		output = utils.ReplaceBytesInBetween(output, indices, []byte(descriptionStr))
 	} else {
 		re := regexp.MustCompile(fmt.Sprintf("(?m)^%s", internal.DescriptionHeader))
@@ -100,9 +99,8 @@ func (a *Action) WriteDocumentation(inputTable, outputTable, description *string
 			if bytes.HasPrefix(match, []byte(internal.DescriptionHeader)) {
 				if descriptionStr != "" {
 					return []byte(fmt.Sprintf("%s\n\n%v", internal.DescriptionHeader, descriptionStr))
-				} else {
-					return []byte(internal.DescriptionHeader)
 				}
+				return []byte(internal.DescriptionHeader)
 			}
 			return match
 		})
@@ -114,11 +112,10 @@ func (a *Action) WriteDocumentation(inputTable, outputTable, description *string
 		[]byte(internal.InputAutoDocEnd),
 	)
 
-
 	inputsStr := strings.TrimSpace(inputTable.String())
 
 	if hasInputsData {
-        output = utils.ReplaceBytesInBetween(output, indices, []byte(inputsStr))
+		output = utils.ReplaceBytesInBetween(output, indices, []byte(inputsStr))
 	} else {
 		re := regexp.MustCompile(fmt.Sprintf("(?m)^%s", internal.InputsHeader))
 		output = re.ReplaceAllFunc(input, func(match []byte) []byte {
@@ -176,8 +173,8 @@ func (a *Action) RenderOutput() error {
 		return err
 	}
 
-    descriptionOutput, err := renderDescription(a.Description)
-    if err != nil {
+	descriptionOutput, err := renderDescription(a.Description)
+	if err != nil {
 		return err
 	}
 
@@ -201,24 +198,24 @@ func (a *Action) RenderOutput() error {
 
 // renderDescription
 func renderDescription(description string) (*strings.Builder, error) {
-    descriptionOutput := &strings.Builder{}
-    _, err := fmt.Fprintln(descriptionOutput, internal.DescriptionAutoDocStart)
+	descriptionOutput := &strings.Builder{}
+	_, err := fmt.Fprintln(descriptionOutput, internal.DescriptionAutoDocStart)
 	if err != nil {
 		return descriptionOutput, err
 	}
 
 	_, err = fmt.Fprintln(descriptionOutput)
-		if err != nil {
-			return descriptionOutput, err
-		}
-    descriptionOutput.WriteString(description)
-    descriptionOutput.WriteString("\n")
+	if err != nil {
+		return descriptionOutput, err
+	}
+	descriptionOutput.WriteString(description)
+	descriptionOutput.WriteString("\n")
 
-    _, err = fmt.Fprint(descriptionOutput, internal.DescriptionAutoDocEnd)
-    if err != nil {
-        return descriptionOutput, err
-    }
-    return descriptionOutput, nil
+	_, err = fmt.Fprint(descriptionOutput, internal.DescriptionAutoDocEnd)
+	if err != nil {
+		return descriptionOutput, err
+	}
+	return descriptionOutput, nil
 }
 
 // renderActionOutputTableOutput renders the action input table

--- a/internal/types/action.go
+++ b/internal/types/action.go
@@ -196,7 +196,7 @@ func (a *Action) RenderOutput() error {
 	return nil
 }
 
-// renderDescription
+// renderDescription renders the description
 func renderDescription(description string) (*strings.Builder, error) {
 	descriptionOutput := &strings.Builder{}
 	_, err := fmt.Fprintln(descriptionOutput, internal.DescriptionAutoDocStart)
@@ -209,7 +209,7 @@ func renderDescription(description string) (*strings.Builder, error) {
 		return descriptionOutput, err
 	}
 	descriptionOutput.WriteString(description)
-	descriptionOutput.WriteString("\n")
+	descriptionOutput.WriteString("\n\n")
 
 	_, err = fmt.Fprint(descriptionOutput, internal.DescriptionAutoDocEnd)
 	if err != nil {

--- a/test/README-action-empty-markers-no-inputs-no-outputs.expected.md
+++ b/test/README-action-empty-markers-no-inputs-no-outputs.expected.md
@@ -2,6 +2,11 @@
 
 Test text ## Inputs
 
+## Description
+<!-- AUTO-DOC-DESCRIPTION:START - Do not remove or modify this section -->
+No description.
+<!-- AUTO-DOC-DESCRIPTION:END -->
+
 ## Inputs
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->

--- a/test/README-action-empty-markers.md
+++ b/test/README-action-empty-markers.md
@@ -1,5 +1,11 @@
 # test/action
 
+## Description
+
+<!-- AUTO-DOC-DESCRIPTION:START - Do not remove or modify this section -->
+No description.
+<!-- AUTO-DOC-DESCRIPTION:END -->
+
 Test text ## Inputs
 
 ## Inputs

--- a/test/README.md
+++ b/test/README.md
@@ -105,3 +105,12 @@ Test text ## Inputs
 |         unmerged_files         | string |                                                                                                                  Returns only files that are Unmerged <br>(U).                                                                                                                   |
 
 <!-- AUTO-DOC-OUTPUT:END -->
+
+
+## Description
+
+<!-- AUTO-DOC-DESCRIPTION:START - Do not remove or modify this section -->
+
+Get all Added, Copied, Modified, Deleted, Renamed, Type changed, Unmerged, Unknown files and directories.
+
+<!-- AUTO-DOC-DESCRIPTION:END -->

--- a/test/action.yml
+++ b/test/action.yml
@@ -1,5 +1,5 @@
 name: Changed Files
-description: Get all Added, Copied, Modified, Deleted, Renamed, Type changed, Unmerged, Unknown files.
+description: Get all Added, Copied, Modified, Deleted, Renamed, Type changed, Unmerged, Unknown files and directories.
 author: tj-actions
 
 inputs:


### PR DESCRIPTION
## Description 

This PR adds code to pull the `description` field for actions and add it to the docs if defined.

I am not a great go dev, so I have tried to keep these changes in line with the existing code base.