### PR TITLE
feat(setup): add nix build instructions

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1747676747,
+        "narHash": "sha256-LXkWBVqilgx7Pohwqu/ABxDVw+Cmi5/Mj2S2mpUH0Fw=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "72841a4a8761d1aed92ef6169a636872c986c76d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,25 @@
+{
+  description = "auto-doc: Github action that turns your reusable workflows and custom actions into easy to read markdown tables.";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-24.11";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+  }: let
+    system = "x86_64-linux";
+  in {
+    packages.x86_64-linux.auto-doc = nixpkgs.legacyPackages.${system}.buildGoModule {
+      pname = "auto-doc";
+      version = "3.6.0";
+
+      src = ./.;
+      vendorHash = "sha256-kO5xCO8bjs2vF4CS35odlhz17jPcpvQ6gdrE61p7x/w=";
+      doCheck = false;
+    };
+
+    packages.x86_64-linux.default = self.packages.x86_64-linux.auto-doc;
+  };
+}


### PR DESCRIPTION
Hi, I wanted to use the CLI on NixOS, but none of the release binaries worked.

So I added build instructions, that generate a binary for NixOS.

It can be used directly, like so:

```bash
# Running directly
nix run github:tj-actions/auto-doc/main

# Installing permanently
nix profile install github:tj-actions/auto-doc/main
```
